### PR TITLE
Fixed bug in EMA for MACD values, previously using the wrong K

### DIFF
--- a/Chapter2/macd.py
+++ b/Chapter2/macd.py
@@ -63,7 +63,7 @@ for close_price in close:
   if ema_macd == 0:
     ema_macd = macd
   else:
-    ema_macd = (macd - ema_macd) * K_slow + ema_macd # signal is EMA of MACD values
+    ema_macd = (macd - ema_macd) * K_macd + ema_macd # signal is EMA of MACD values
 
   macd_values.append(macd)
   macd_signal_values.append(ema_macd)


### PR DESCRIPTION
It looks like there is a bug in Chapter 2, when computing the EMA for MACD (MACD signal), since it is using a different K that the one stated in the book.