### PR TITLE
Removed batched graph effect

### DIFF
--- a/Chapter2/seasonality.py
+++ b/Chapter2/seasonality.py
@@ -59,7 +59,7 @@ def plot_rolling_statistics_ts(ts, titletext,ytext, window_size=12):
     plt.legend(loc='best')
     plt.ylabel(ytext)
     plt.title(titletext)
-    plt.show(block=False)
+    plt.show()
 
 
 plot_rolling_statistics_ts(goog_monthly_return[1:],'GOOG prices rolling mean and standard deviation','Monthly return')


### PR DESCRIPTION
Seasonality was sticking all three graphs called with function plot_rolling_statistics_ts on the same chart making it unrecognizable as per the charts in the book; removing this shows the chart as they are displayed in the book.